### PR TITLE
Document usage with FFmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ There's nothing stopping us from using a different rate than the actual device r
 $ parec --channels=1 --device="${PASOURCE}" --raw | specgram -l -r 1e-8
 ```
 
+#### Usage with FFmpeg
+
+In order to generate a spectrogram for an encoded audio file, it is neccesarily to decode it first. This can be done with FFmpeg, using any of the [raw audio formats available](https://trac.ffmpeg.org/wiki/audio%20types#SampleFormats).
+
+For example, to generate the spectrogram for an MP3 file:
+
+```bash
+$ ffmpeg -i input.mp3 -f s16le - | specgram output.png
+```
+
+Or, in order to use 32-bit data:
+
+```bash
+$ ffmpeg -i input.mp3 -f s32le - | specgram -d s32 output.png
+```
+Note that you will have to manually stop specgram with a SIGINT once the ffmpeg stream is finished.
+
 ### FFT options
 
 The FFT window width can be specified with ```-f, --fft_width``` and the stride, that is the distance between the beginning of two subsequent FFT windows, can be specified with ```-g, --fft_stride```:


### PR DESCRIPTION
Needed a few spectrograms to doublecheck what frequencies are lost when encoding audio with a lower bitrate; this tool came in handy!

Since I had to deal with encoded audio, and `specgram` does not support it natively, I had to pipe it out from ffmpeg first. This PR documents how that can be done, as `ffmpeg` is not the most user-friendly piece of software when it comes to figuring out command-line options. :sweat_smile: 

Hope it's useful!

(also, I wonder if it would make sense for `specgram` to stop whenever the stream ends; I'm guessing around `AsyncInputReader::ReachedEOF()`. Since, once we get an EOF on stdin, there should be no way to get more data in... right?)